### PR TITLE
Add prelude module and clean imports

### DIFF
--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,6 +1,6 @@
 use crate::forest::ForestError;
-use crate::metadata::{self, JobParams, MetadataError, MetadataStore};
-use crate::runs::RunError;
+use crate::prelude::*;
+use crate::metadata::{self, MetadataStore};
 use crate::storage::{ObjectStore, StorageError};
 
 mod table_buffer_compaction;

--- a/src/jobs/table_buffer_compaction.rs
+++ b/src/jobs/table_buffer_compaction.rs
@@ -4,8 +4,8 @@ use futures::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use super::JobError;
 use crate::forest::ForestImpl;
 use crate::k_way;
+use crate::prelude::*;
 use crate::metadata::{self, MetadataStore};
-use crate::runs::{RunError, WriteOperation};
 use crate::storage::ObjectStore;
 
 // Define a type alias for the boxed stream

--- a/src/jobs/table_tree_compaction.rs
+++ b/src/jobs/table_tree_compaction.rs
@@ -6,8 +6,8 @@ use futures::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use super::JobError;
 use crate::forest::ForestImpl;
 use crate::k_way;
+use crate::prelude::*;
 use crate::metadata::{self, MetadataStore};
-use crate::runs::{RunError, RunId, Stats, StatsV1, WriteOperation};
 use crate::storage::ObjectStore;
 
 // Define a type alias for the boxed stream

--- a/src/jobs/wal_compaction.rs
+++ b/src/jobs/wal_compaction.rs
@@ -4,8 +4,8 @@ use tokio::sync::mpsc;
 use super::JobError;
 use crate::forest::ForestImpl;
 use crate::k_way;
-use crate::metadata::{self, MetadataStore, TableID};
-use crate::runs::{RunError, Stats, WriteOperation};
+use crate::prelude::*;
+use crate::metadata::{self, MetadataStore};
 use crate::storage::ObjectStore;
 
 pub async fn execute(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod k_way;
 pub mod metadata;
 mod pod_watcher;
 mod runs;
+pub mod prelude;
 pub mod storage;
 #[cfg(test)]
 pub mod test_utils;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -13,6 +13,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::types::JsonValue;
 use thiserror::Error;
 
+use crate::prelude::*;
 use crate::proto;
 
 #[derive(Error, Debug)]
@@ -233,9 +234,9 @@ impl From<proto::run_metadata::BelongsTo> for BelongsTo {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct RunMetadata {
-    pub id: crate::runs::RunId,
+    pub id: RunId,
     pub belongs_to: BelongsTo,
-    pub stats: crate::runs::Stats,
+    pub stats: Stats,
 }
 
 impl From<RunMetadata> for proto::RunMetadata {
@@ -266,8 +267,8 @@ impl From<proto::RunMetadata> for RunMetadata {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct ChangelogEntryV1 {
-    pub runs_added: Vec<crate::runs::RunId>,
-    pub runs_removed: Vec<crate::runs::RunId>,
+    pub runs_added: Vec<RunId>,
+    pub runs_removed: Vec<RunId>,
 }
 
 impl From<ChangelogEntryV1> for proto::ChangelogEntryV1 {
@@ -395,24 +396,24 @@ pub trait MetadataStoreTrait: Send + Sync + 'static {
     // WAL & COMPACTIONS
     async fn append_wal(
         &self,
-        run_ids: Vec<(crate::runs::RunId, crate::runs::Stats)>,
+        run_ids: Vec<(RunId, Stats)>,
     ) -> Result<SeqNo, MetadataError>;
     async fn append_wal_compaction(
         &self,
         job_id: JobId,
-        compacted: Vec<crate::runs::RunId>,
-        new_table_runs: Vec<(crate::runs::RunId, TableID, crate::runs::Stats)>,
+        compacted: Vec<RunId>,
+        new_table_runs: Vec<(RunId, TableID, Stats)>,
     ) -> Result<SeqNo, MetadataError>;
     async fn append_table_compaction(
         &self,
         job_id: JobId,
-        compacted: Vec<crate::runs::RunId>,
+        compacted: Vec<RunId>,
         new_runs: Vec<RunMetadata>,
     ) -> Result<SeqNo, MetadataError>;
     async fn get_run_metadata_batch(
         &self,
-        run_ids: Vec<crate::runs::RunId>,
-    ) -> Result<HashMap<crate::runs::RunId, RunMetadata>, MetadataError>;
+        run_ids: Vec<RunId>,
+    ) -> Result<HashMap<RunId, RunMetadata>, MetadataError>;
 
     // JOBS
     async fn schedule_job(&self, job_params: JobParams) -> Result<JobId, MetadataError>;
@@ -461,7 +462,7 @@ impl PostgresMetadataStore {
     async fn append_wal_attempt(
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-        run_ids_with_stats: &[(crate::runs::RunId, crate::runs::Stats)],
+        run_ids_with_stats: &[(RunId, Stats)],
     ) -> Result<SeqNo, sqlx::Error> {
         let first_seq_no: i64 = sqlx::query_scalar("SELECT nextval('changelog_id_seq')")
             .fetch_one(&mut **transaction) // Deref the mutable reference
@@ -566,8 +567,8 @@ impl PostgresMetadataStore {
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         job_id: JobId,
-        compacted: &[crate::runs::RunId],
-        new_table_runs: &[(crate::runs::RunId, TableID, crate::runs::Stats)],
+        compacted: &[RunId],
+        new_table_runs: &[(RunId, TableID, Stats)],
     ) -> Result<SeqNo, MetadataError> {
         let compacted_strings: Vec<String> = compacted.iter().map(|id| id.to_string()).collect();
         let deleted_count_result = sqlx::query!(
@@ -795,7 +796,7 @@ impl MetadataStoreTrait for PostgresMetadataStore {
 
     async fn append_wal(
         &self,
-        run_ids_with_stats: Vec<(crate::runs::RunId, crate::runs::Stats)>,
+        run_ids_with_stats: Vec<(RunId, Stats)>,
     ) -> Result<SeqNo, MetadataError> {
         loop {
             // Retry loop for transaction serialization failures
@@ -841,8 +842,8 @@ impl MetadataStoreTrait for PostgresMetadataStore {
     async fn append_wal_compaction(
         &self,
         job_id: JobId,
-        compacted: Vec<crate::runs::RunId>,
-        new_table_runs: Vec<(crate::runs::RunId, TableID, crate::runs::Stats)>,
+        compacted: Vec<RunId>,
+        new_table_runs: Vec<(RunId, TableID, Stats)>,
     ) -> Result<SeqNo, MetadataError> {
         loop {
             // Retry loop
@@ -902,7 +903,7 @@ impl MetadataStoreTrait for PostgresMetadataStore {
     async fn append_table_compaction(
         &self,
         job_id: JobId,
-        compacted: Vec<crate::runs::RunId>,
+        compacted: Vec<RunId>,
         new_runs: Vec<RunMetadata>,
     ) -> Result<SeqNo, MetadataError> {
         let mut transaction = self.pg_pool.begin().await?;
@@ -994,8 +995,8 @@ impl MetadataStoreTrait for PostgresMetadataStore {
 
     async fn get_run_metadata_batch(
         &self,
-        run_ids: Vec<crate::runs::RunId>,
-    ) -> Result<HashMap<crate::runs::RunId, RunMetadata>, MetadataError> {
+        run_ids: Vec<RunId>,
+    ) -> Result<HashMap<RunId, RunMetadata>, MetadataError> {
         let run_ids_strings: Vec<String> = run_ids.iter().map(|id| id.to_string()).collect();
         let rows = sqlx::query!(
             r#"
@@ -1012,11 +1013,11 @@ impl MetadataStoreTrait for PostgresMetadataStore {
             .map(|row| {
                 let belongs_to: BelongsTo = serde_json::from_value(row.belongs_to)
                     .map_err(MetadataError::JsonSerdeError)?;
-                let stats: crate::runs::Stats =
+                let stats: Stats =
                     serde_json::from_value(row.stats).map_err(MetadataError::JsonSerdeError)?;
 
                 Ok(RunMetadata {
-                    id: crate::runs::RunId(row.id),
+                    id: RunId(row.id),
                     belongs_to,
                     stats,
                 })

--- a/src/orchestrator_service.rs
+++ b/src/orchestrator_service.rs
@@ -6,10 +6,8 @@ use thiserror::Error;
 use tonic::{Request, Response, Status};
 
 use crate::forest::{Forest, ForestError, ForestImpl, Snapshot};
-use crate::metadata::{
-    JobParams, Level, MetadataError, MetadataStore, SeqNo, SnapshotID, TableConfig, TableID,
-    TableName,
-};
+use crate::prelude::*;
+use crate::metadata::{self, MetadataStore};
 use crate::proto::orchestrator_service_server::OrchestratorService;
 use crate::storage::{self, ObjectStore};
 use crate::{Config, metadata, proto};
@@ -104,7 +102,7 @@ impl MyOrchestrator {
                 .wal
                 .values()
                 .map(|r| match &r.stats {
-                    crate::runs::Stats::StatsV1(stats) => stats.size_bytes,
+                    Stats::StatsV1(stats) => stats.size_bytes,
                 })
                 .sum::<u64>();
 
@@ -123,7 +121,7 @@ impl MyOrchestrator {
                     .buffer
                     .values()
                     .map(|r| match &r.stats {
-                        crate::runs::Stats::StatsV1(stats) => stats.size_bytes,
+                        Stats::StatsV1(stats) => stats.size_bytes,
                     })
                     .sum::<u64>();
 
@@ -147,7 +145,7 @@ impl MyOrchestrator {
                     let total_level_size = runs
                         .values()
                         .map(|r| match &r.stats {
-                            crate::runs::Stats::StatsV1(stats) => stats.size_bytes,
+                            Stats::StatsV1(stats) => stats.size_bytes,
                         })
                         .sum::<u64>();
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,9 @@
+pub use crate::metadata::{
+    BelongsTo, ChangelogEntry, ChangelogEntryV1, ChangelogEntryWithID, JobId,
+    JobParams, JobStatus, Level, MetadataError, RunMetadata, SeqNo, SnapshotID,
+    TableConfig, TableID, TableName,
+};
+
+pub use crate::runs::{
+    Key, RunError, RunId, SearchResult, Stats, StatsV1, Value, WriteOperation,
+};

--- a/src/reader_service.rs
+++ b/src/reader_service.rs
@@ -9,12 +9,12 @@ use tracing::{error, info};
 
 use crate::consistent_hashring::ConsistentHashRing;
 use crate::forest::{Forest, ForestError, Snapshot as ForestState};
-use crate::metadata::{self, MetadataStore, SeqNo, TableCache};
+use crate::prelude::*;
+use crate::metadata::{self, MetadataStore, TableCache};
 use crate::pod_watcher::{self, PodChange, PodWatcherError};
 use crate::proto;
 use crate::proto::cache_service_client::CacheServiceClient;
 use crate::proto::reader_service_server::ReaderService;
-use crate::runs::{RunError, Stats, WriteOperation};
 use crate::storage::ObjectStore;
 
 #[derive(Debug, Error)]
@@ -611,12 +611,12 @@ mod tests {
 
     use super::*;
     use crate::forest::{Forest, MockForestTrait};
-    use crate::metadata::{BelongsTo, RunMetadata, SeqNo, TableConfig, TableID, TableName};
+    use crate::prelude::*;
+    use crate::metadata::{TableCache};
     use crate::proto::{
         GetBatchRequest, GetFromRunItem, GetFromRunRequest, GetFromRunResponse, ScanFromRunRequest,
         ScanFromRunResponse, ScanRequest, TableGetBatchRequest, get_from_run_item,
     };
-    use crate::runs::{RunId, Stats, StatsV1};
 
     async fn create_test_forest(seq_no: SeqNo, runs: Vec<RunMetadata>) -> Forest {
         let state = ForestState::from_raw(seq_no, runs).await;


### PR DESCRIPTION
## Summary
- create `prelude.rs` re-exporting common types
- expose the new module from `lib.rs`
- update imports across modules to use the prelude

## Testing
- `just check` *(fails: `just: command not found`)*
- `cargo check` *(fails: could not download Rust toolchain)*
