### PR TITLE
Skip Docker tests when daemon missing

### DIFF
--- a/src/cache_service.rs
+++ b/src/cache_service.rs
@@ -166,7 +166,7 @@ mod tests {
     use crate::proto::{self, GetFromRunRequest, ScanFromRunRequest};
     use crate::runs::{RunError, RunId, Stats, WriteOperation};
     use crate::storage::ObjectStore;
-    use crate::test_utils::setup_test_object_store;
+    use crate::test_utils::{docker_is_available, setup_test_object_store};
 
     async fn create_and_store_run(
         object_store: &ObjectStore,
@@ -194,6 +194,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_my_cache_new() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache = MyCache::new(object_store).await;
         assert!(cache.is_ok());
@@ -201,6 +205,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_from_run_simple() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 
@@ -255,6 +263,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_from_run_simple() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 
@@ -343,6 +355,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_from_run_multiple_runs() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1258,10 +1258,14 @@ impl TableCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::{docker_is_available, setup_test_db};
 
     #[tokio::test]
     async fn test_tables() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         // Setup test database
         let (metadata_store, _container) = setup_test_db().await.unwrap();
 
@@ -1295,6 +1299,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_schedule_and_get_wal_compaction_job() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         // Setup test database
         let (metadata_store, _container) = setup_test_db().await.unwrap();
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,9 +7,21 @@ use testcontainers_modules::minio;
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::ContainerAsync;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use std::process::{Command, Stdio};
 
 use crate::metadata::{MetadataError, MetadataStore, PostgresMetadataStore};
 use crate::storage::{ObjectStore, S3ObjectStore, StorageError};
+
+/// Returns `true` if Docker is available and responding, otherwise `false`.
+pub fn docker_is_available() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
 
 /// Sets up a test PostgreSQL instance in a container for testing.
 /// Returns the metadata store connected to the test DB and the container handle.

--- a/src/writer_service.rs
+++ b/src/writer_service.rs
@@ -188,10 +188,14 @@ impl WriterService for MyWriter {
 mod tests {
     use super::*;
     use crate::metadata::TableConfig;
-    use crate::test_utils::{setup_test_db, setup_test_object_store};
+    use crate::test_utils::{docker_is_available, setup_test_db, setup_test_object_store};
 
     #[tokio::test]
     async fn test_writer_service() {
+        if !docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
         let (metadata, _postgres) = setup_test_db().await.unwrap();
         let (storage, _minio) = setup_test_object_store().await.unwrap();
 


### PR DESCRIPTION
## Summary
- check if Docker daemon is running
- skip Docker-dependent tests when Docker isn't available

## Testing
- `cargo test --workspace --quiet`