### PR TITLE
Add requires_docker macro

### DIFF
--- a/src/cache_service.rs
+++ b/src/cache_service.rs
@@ -164,9 +164,10 @@ mod tests {
 
     use super::*;
     use crate::proto::{self, GetFromRunRequest, ScanFromRunRequest};
+    use crate::requires_docker;
     use crate::runs::{RunError, RunId, Stats, WriteOperation};
     use crate::storage::ObjectStore;
-    use crate::test_utils::{docker_is_available, setup_test_object_store};
+    use crate::test_utils::setup_test_object_store;
 
     async fn create_and_store_run(
         object_store: &ObjectStore,
@@ -194,10 +195,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_my_cache_new() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache = MyCache::new(object_store).await;
         assert!(cache.is_ok());
@@ -205,10 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_from_run_simple() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 
@@ -263,10 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_from_run_simple() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 
@@ -355,10 +347,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scan_from_run_multiple_runs() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         let (object_store, _container) = setup_test_object_store().await.unwrap();
         let cache_service = MyCache::new(object_store.clone()).await.unwrap();
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1258,14 +1258,12 @@ impl TableCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{docker_is_available, setup_test_db};
+    use crate::requires_docker;
+    use crate::test_utils::setup_test_db;
 
     #[tokio::test]
     async fn test_tables() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         // Setup test database
         let (metadata_store, _container) = setup_test_db().await.unwrap();
 
@@ -1299,10 +1297,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_schedule_and_get_wal_compaction_job() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         // Setup test database
         let (metadata_store, _container) = setup_test_db().await.unwrap();
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_s3::config::{Credentials, SharedCredentialsProvider};
+use std::process::{Command, Stdio};
 use testcontainers_modules::minio;
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::ContainerAsync;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
-use std::process::{Command, Stdio};
 
 use crate::metadata::{MetadataError, MetadataStore, PostgresMetadataStore};
 use crate::storage::{ObjectStore, S3ObjectStore, StorageError};
@@ -21,6 +21,17 @@ pub fn docker_is_available() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+/// Macro to skip tests when Docker is not available.
+#[macro_export]
+macro_rules! requires_docker {
+    () => {
+        if !$crate::test_utils::docker_is_available() {
+            eprintln!("Docker not running - skipping test");
+            return;
+        }
+    };
 }
 
 /// Sets up a test PostgreSQL instance in a container for testing.

--- a/src/writer_service.rs
+++ b/src/writer_service.rs
@@ -188,14 +188,12 @@ impl WriterService for MyWriter {
 mod tests {
     use super::*;
     use crate::metadata::TableConfig;
-    use crate::test_utils::{docker_is_available, setup_test_db, setup_test_object_store};
+    use crate::requires_docker;
+    use crate::test_utils::{setup_test_db, setup_test_object_store};
 
     #[tokio::test]
     async fn test_writer_service() {
-        if !docker_is_available() {
-            eprintln!("Docker not running - skipping test");
-            return;
-        }
+        requires_docker!();
         let (metadata, _postgres) = setup_test_db().await.unwrap();
         let (storage, _minio) = setup_test_object_store().await.unwrap();
 


### PR DESCRIPTION
## Summary
- add `requires_docker!` macro for docker-based tests
- use `requires_docker!()` in writer, cache, and metadata tests

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUST_BACKTRACE=1 cargo test`