### PR TITLE
Store AWS credentials in Kubernetes secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "clap",
  "futures",
  "hostname",
+ "http 1.3.1",
  "k8s-openapi",
  "kube",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rustls = "0.23"
 sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "derive", "macros", "json" ] }
 serde_json = "1.0"
 bytes = "1.10"
+http = "1"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/bin/worker.rs
+++ b/bin/worker.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use aws_sdk_s3::Client as S3Client;
+use aws_sdk_s3::config::SharedCredentialsProvider;
 use clap::Parser;
-use kube::Client;
 use rustls::crypto::aws_lc_rs;
+use skyvault::k8s;
 use skyvault::metadata::JobId;
 use skyvault::{PostgresConfig, jobs, metadata, storage};
 use tokio::fs;
@@ -45,7 +46,7 @@ async fn main() -> Result<()> {
     let version = env!("CARGO_PKG_VERSION");
 
     // Initialize K8s client
-    let k8s_client = Client::try_default()
+    let k8s_client = k8s::create_k8s_client()
         .await
         .context("Failed to create Kubernetes client")?;
 
@@ -74,7 +75,13 @@ async fn main() -> Result<()> {
     let metadata_store = Arc::new(metadata::PostgresMetadataStore::new(metadata_url).await?);
 
     // Create S3 client with path style URLs
-    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let aws_creds = k8s::get_aws_credentials(k8s_client.clone(), &current_namespace)
+        .await
+        .context("Failed to load AWS credentials from Kubernetes secret")?;
+    let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .credentials_provider(SharedCredentialsProvider::new(aws_creds))
+        .load()
+        .await;
     let s3_config = aws_sdk_s3::config::Builder::from(&aws_config)
         .force_path_style(true)
         .build();

--- a/charts/skyvault/templates/aws-secrets.yaml
+++ b/charts/skyvault/templates/aws-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: skyvault-aws-credentials
+  labels:
+    {{- include "skyvault.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: {{ .Values.common.env.AWS_ACCESS_KEY_ID | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.common.env.AWS_SECRET_ACCESS_KEY | b64enc | quote }}

--- a/charts/skyvault/templates/minio-deployment.yaml
+++ b/charts/skyvault/templates/minio-deployment.yaml
@@ -33,9 +33,15 @@ spec:
               protocol: TCP
           env:
             - name: MINIO_ROOT_USER
-              value: {{ .Values.common.env.AWS_ACCESS_KEY_ID | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: skyvault-aws-credentials
+                  key: AWS_ACCESS_KEY_ID
             - name: MINIO_ROOT_PASSWORD
-              value: {{ .Values.common.env.AWS_SECRET_ACCESS_KEY | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: skyvault-aws-credentials
+                  key: AWS_SECRET_ACCESS_KEY
           args:
             - server
             - /data # MinIO still needs a path, even without PVC

--- a/charts/skyvault/templates/skyvault-deployments.yaml
+++ b/charts/skyvault/templates/skyvault-deployments.yaml
@@ -37,8 +37,10 @@ spec:
           env:
             # Common environment variables
             {{- range $key, $value := $.Values.common.env }}
+            {{- if not (or (eq $key "AWS_ACCESS_KEY_ID") (eq $key "AWS_SECRET_ACCESS_KEY")) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             
             # Instance-specific environment variables

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result as AnyhowResult, anyhow};
+use aws_sdk_s3::config::Credentials;
+use http::Request;
+use k8s_openapi::api::core::v1::Secret;
+use kube::{Api, Client};
+
+pub const AWS_SECRET_NAME: &str = "skyvault-aws-credentials";
+pub const AWS_ACCESS_KEY_ID_KEY: &str = "AWS_ACCESS_KEY_ID";
+pub const AWS_SECRET_ACCESS_KEY_KEY: &str = "AWS_SECRET_ACCESS_KEY";
+
+pub async fn create_k8s_client() -> std::result::Result<Client, kube::Error> {
+    let client = Client::try_default().await?;
+    let req = Request::builder()
+        .uri("/livez")
+        .body(Vec::new())
+        .map_err(kube::Error::HttpError)?;
+    client.request_text(req).await?;
+    Ok(client)
+}
+
+pub async fn get_aws_credentials(client: Client, namespace: &str) -> AnyhowResult<Credentials> {
+    let api: Api<Secret> = Api::namespaced(client, namespace);
+    match api.get(AWS_SECRET_NAME).await {
+        Ok(secret) => {
+            let data = secret.data.ok_or_else(|| {
+                anyhow!(
+                    "Secret '{}' in namespace '{}' does not contain any data",
+                    AWS_SECRET_NAME,
+                    namespace
+                )
+            })?;
+
+            let access_bytes = data.get(AWS_ACCESS_KEY_ID_KEY).ok_or_else(|| {
+                anyhow!(
+                    "Secret '{}' in namespace '{}' does not contain key '{}'",
+                    AWS_SECRET_NAME,
+                    namespace,
+                    AWS_ACCESS_KEY_ID_KEY
+                )
+            })?;
+            let secret_bytes = data.get(AWS_SECRET_ACCESS_KEY_KEY).ok_or_else(|| {
+                anyhow!(
+                    "Secret '{}' in namespace '{}' does not contain key '{}'",
+                    AWS_SECRET_NAME,
+                    namespace,
+                    AWS_SECRET_ACCESS_KEY_KEY
+                )
+            })?;
+
+            let access_key = String::from_utf8(access_bytes.0.clone()).context(format!(
+                "Failed to decode key '{}' from secret '{}'",
+                AWS_ACCESS_KEY_ID_KEY, AWS_SECRET_NAME
+            ))?;
+            let secret_key = String::from_utf8(secret_bytes.0.clone()).context(format!(
+                "Failed to decode key '{}' from secret '{}'",
+                AWS_SECRET_ACCESS_KEY_KEY, AWS_SECRET_NAME
+            ))?;
+
+            Ok(Credentials::new(access_key, secret_key, None, None, "k8s"))
+        },
+        Err(e) => Err(anyhow!(
+            "Failed to get secret '{}' in namespace '{}': {}",
+            AWS_SECRET_NAME,
+            namespace,
+            e
+        )),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod writer_service;
 mod consistent_hashring;
 mod forest;
 pub mod jobs;
+pub mod k8s;
 mod k_way;
 pub mod metadata;
 mod pod_watcher;

--- a/src/pod_watcher.rs
+++ b/src/pod_watcher.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
+use crate::k8s;
 use async_stream::stream;
 use futures::{Stream, StreamExt, pin_mut};
 use k8s_openapi::api::core::v1::Pod;
-use kube::Client;
 use kube::api::Api;
 use kube::runtime::watcher;
 use thiserror::Error;
@@ -32,7 +32,7 @@ pub enum PodWatcherError {
 pub async fn watch()
 -> Result<impl Stream<Item = Result<PodChange, PodWatcherError>>, PodWatcherError> {
     // Create Kubernetes client
-    let client = Client::try_default().await?;
+    let client = k8s::create_k8s_client().await?;
 
     // Read namespace from the mounted ServiceAccount secret
     let namespace = fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")?


### PR DESCRIPTION
## Summary
- add aws credential secret template and fetch it via new `k8s` module
- create helper to build K8s client with `/livez` health check
- use secret-based credentials for S3 clients
- remove credentials from skyvault env in helm chart

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUST_BACKTRACE=1 cargo test`
- `helm lint charts/skyvault` *(fails: `helm: command not found`)*