### PR TITLE
Add sentry tracing integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ prost = "0.13"
 clap = { version = "4.5", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+sentry = { version = "0.32", features = ["tracing"] }
+sentry-tracing = "0.32"
 async-trait = "0.1"
 thiserror = "2.0"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Skyvault is a high-performance, scalable object-store backed key-value store.
 1. Run `just build` to build skyvault and push container image to minikube.
 2. Run `just deploy` to start everything in k8s.
 3. Run `just smoke` to run some simple smoke tests against this.
+4. Set the `SENTRY_DSN` environment variable if you want errors reported to
+   Sentry.
 
 ## Security
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -5,9 +5,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustls::crypto::aws_lc_rs;
 use skyvault::config::{PostgresConfig, S3Config};
-use skyvault::{k8s, metadata, storage};
+use skyvault::{k8s, metadata, storage, telemetry};
 use tracing::info;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser, Clone)]
 #[command(name = "skyvault", about = "A gRPC server for skyvault.")]
@@ -33,13 +32,7 @@ pub struct Config {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .compact()
-        .with_file(true)
-        .with_line_number(true)
-        .with_thread_ids(true)
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    let _sentry = telemetry::init();
 
     aws_lc_rs::default_provider()
         .install_default()

--- a/bin/worker.rs
+++ b/bin/worker.rs
@@ -5,9 +5,8 @@ use clap::Parser;
 use rustls::crypto::aws_lc_rs;
 use skyvault::config::{PostgresConfig, S3Config};
 use skyvault::metadata::JobID;
-use skyvault::{jobs, k8s, metadata, storage};
+use skyvault::{jobs, k8s, metadata, storage, telemetry};
 use tracing::info;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[command(name = "worker", about = "A worker for skyvault.")]
@@ -24,13 +23,7 @@ pub struct Config {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .compact()
-        .with_file(true)
-        .with_line_number(true)
-        .with_thread_ids(true)
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    let _sentry = telemetry::init();
 
     aws_lc_rs::default_provider()
         .install_default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod orchestrator_service;
 pub mod reader_service;
 pub mod storage;
+pub mod telemetry;
 pub mod writer_service;
 
 mod consistent_hashring;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,26 @@
+use sentry::ClientInitGuard;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub fn init() -> Option<ClientInitGuard> {
+    let guard = std::env::var("SENTRY_DSN").ok().map(|dsn| {
+        sentry::init((dsn, sentry::ClientOptions {
+            release: Some(env!("CARGO_PKG_VERSION").into()),
+            ..Default::default()
+        }))
+    });
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_file(true)
+        .with_line_number(true)
+        .with_thread_ids(true);
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(fmt_layer)
+        .with(sentry_tracing::layer())
+        .init();
+
+    guard
+}


### PR DESCRIPTION
## Summary
- integrate `sentry` with tracing
- expose telemetry init helper
- hook telemetry into the server and worker binaries
- document `SENTRY_DSN`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings` *(fails: could not fetch crates)*
- `RUST_BACKTRACE=1 cargo test` *(fails: could not fetch crates)*