### PR TITLE
Add structured error fields

### DIFF
--- a/src/forest.rs
+++ b/src/forest.rs
@@ -231,7 +231,7 @@ impl ForestImpl {
         let processor = forest.clone();
         tokio::spawn(async move {
             if let Err(e) = processor.process_changelog_stream(stream).await {
-                error!("Changelog processor terminated with error: {e}");
+                error!(error = %e, "Changelog processor terminated");
             }
         });
 
@@ -253,7 +253,7 @@ impl ForestImpl {
                     self.process_changelog_entry(entry).await?;
                 },
                 Err(e) => {
-                    error!("Error reading from changelog: {e}");
+                    error!(error = %e, "Error reading from changelog");
                     // Continue processing despite errors
                 },
             }

--- a/src/reader_service.rs
+++ b/src/reader_service.rs
@@ -61,7 +61,7 @@ impl ConsistentHashCM {
                         hashring_clone.lock().unwrap().remove_node(&pod);
                     },
                     Err(e) => {
-                        error!("Error watching pods: {e}");
+                        error!(error = %e, "Error watching pods");
                     },
                 }
             }
@@ -101,7 +101,7 @@ impl ConsistentHashCM {
 
 #[tonic::async_trait]
 impl ConnectionManager for ConsistentHashCM {
-    #[tracing::instrument(skip(self), level = "debug")]
+    #[tracing::instrument(skip(self, request), level = "debug", fields(client_addr = ?request.remote_addr()))]
     async fn table_get_batch_run(
         &self,
         routing_key: String,
@@ -129,7 +129,7 @@ impl ConnectionManager for ConsistentHashCM {
         run_conn.get_from_run(request).await
     }
 
-    #[tracing::instrument(skip(self), level = "debug")]
+    #[tracing::instrument(skip(self, request), level = "debug", fields(client_addr = ?request.remote_addr()))]
     async fn table_scan_run(
         &self,
         routing_key: String,
@@ -519,7 +519,7 @@ impl MyReader {
             })
             .take(request.max_results as usize)
             .map_err(|run_error: RunError| {
-                error!("Error during k-way merge or run scan: {}", run_error);
+                error!(error = %run_error, "Error during k-way merge or run scan");
                 Status::internal(format!("Scan failed: {run_error}"))
             })
             .try_collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- add `error` fields to tracing events for structured logging
- track client address in reader service instrumentation

Formatted with `cargo fmt`, linted with `cargo clippy -- -D warnings`, and tested with `cargo test`.
