### PR TITLE
Add basic metrics instrumentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-aws-lc-rs", 
 serde_json = "1.0"
 bytes = "1.10"
 http = "1"
+hyper = "1"
+metrics = "0.21"
+metrics-exporter-prometheus = "0.13"
+tower = "0.5"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustls::crypto::aws_lc_rs;
 use skyvault::config::{PostgresConfig, S3Config};
-use skyvault::{k8s, metadata, storage};
+use skyvault::{k8s, metadata, metrics, storage};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -29,6 +29,9 @@ pub struct Config {
 
     #[arg(long, env = "SKYVAULT_ENABLE_ORCHESTRATOR", default_value = "true")]
     pub enable_orchestrator: bool,
+
+    #[arg(long, env = "SKYVAULT_METRICS_ADDR", value_parser = clap::value_parser!(SocketAddr), default_value = "0.0.0.0:9095")]
+    pub metrics_addr: SocketAddr,
 }
 
 #[tokio::main]
@@ -47,6 +50,9 @@ async fn main() -> Result<()> {
 
     let config = Config::parse();
     let version = env!("CARGO_PKG_VERSION");
+
+    let handle = metrics::init_recorder();
+    tokio::spawn(metrics::serve(config.metrics_addr, handle.clone()));
 
     // Initialize K8s client
     let current_namespace = k8s::get_namespace()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use tonic::transport::Server;
 use tonic_health::ServingStatus;
 
+use crate::metrics;
+
 pub mod proto {
     tonic::include_proto!("skyvault.v1");
 
@@ -15,6 +17,7 @@ pub mod proto {
 
 pub mod cache_service;
 pub mod config;
+pub mod metrics;
 pub mod orchestrator_service;
 pub mod reader_service;
 pub mod storage;
@@ -105,7 +108,9 @@ impl Builder {
             .build_v1()
             .expect("Failed to build reflection service");
 
-        let mut builder = Server::builder().add_service(reflection_service);
+        let mut builder = Server::builder()
+            .layer(metrics::MetricsLayer)
+            .add_service(reflection_service);
 
         if self.enable_writer {
             let writer = writer_service::MyWriter::new(self.metadata.clone(), self.storage.clone());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,101 @@
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use metrics::{histogram, increment_counter};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use tower::{Layer, Service};
+
+pub fn init_recorder() -> PrometheusHandle {
+    let builder = PrometheusBuilder::new();
+    let recorder = builder.build_recorder();
+    let handle = builder.build_handle();
+    metrics::set_boxed_recorder(Box::new(recorder)).expect("failed to install metrics recorder");
+    handle
+}
+
+pub async fn serve(addr: SocketAddr, handle: PrometheusHandle) {
+    let make_svc = make_service_fn(move |_| {
+        let handle = handle.clone();
+        async move {
+            Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                let handle = handle.clone();
+                async move {
+                    if req.uri().path() == "/metrics" {
+                        let body = handle.render();
+                        Ok::<_, hyper::Error>(Response::new(Body::from(body)))
+                    } else {
+                        Ok::<_, hyper::Error>(
+                            Response::builder().status(404).body(Body::empty()).unwrap(),
+                        )
+                    }
+                }
+            }))
+        }
+    });
+
+    if let Err(e) = Server::bind(&addr).serve(make_svc).await {
+        tracing::error!(error = %e, "metrics server error");
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct MetricsLayer;
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService { inner }
+    }
+}
+
+pub struct MetricsService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<http::Request<B>> for MetricsService<S>
+where
+    S: Service<http::Request<B>> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        let path = req.uri().path().to_string();
+        let start = Instant::now();
+        let fut = self.inner.call(req);
+        Box::pin(async move {
+            let result = fut.await;
+            if let Some((service, method)) = parse_method(&path) {
+                let elapsed = start.elapsed().as_secs_f64();
+                histogram!("grpc_request_duration_seconds", elapsed, "service" => service.clone(), "method" => method.clone());
+                if result.is_ok() {
+                    increment_counter!("grpc_requests_total", "service" => service, "method" => method, "status" => "ok");
+                } else {
+                    increment_counter!("grpc_requests_total", "service" => service, "method" => method, "status" => "error");
+                }
+            }
+            result
+        })
+    }
+}
+
+fn parse_method(path: &str) -> Option<(String, String)> {
+    let mut parts = path.split('/');
+    parts.next()?;
+    let service = parts.next()?.to_string();
+    let method = parts.next()?.to_string();
+    Some((service, method))
+}


### PR DESCRIPTION
## Summary
- add Prometheus recorder and tower `MetricsLayer`
- expose metrics via `/metrics` HTTP endpoint
- record gRPC request metrics with a tonic middleware
- start metrics server in the main binary
- include new dependencies

Formatted with `cargo fmt`.
Linted with `cargo clippy` *(failed: could not fetch crates)*.
Ran tests with `cargo test` *(failed: could not fetch crates)*.