### PR TITLE
ci: bump GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 1
 
@@ -34,7 +34,7 @@ jobs:
         protoc --version
 
     - name: Install just
-      uses: extractions/setup-just@v3
+      uses: extractions/setup-just@v4
 
     - name: Run tests
       env:
@@ -56,15 +56,15 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 1
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       VERSION_NO_V: ${{ steps.generate_version.outputs.VERSION_NO_V }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,17 +105,17 @@ jobs:
           chmod +x ./binaries/*
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry (early)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker Image for scanning (using pre-built binaries)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.release
@@ -129,7 +129,7 @@ jobs:
 
       - name: Scan Docker Image with Trivy
         id: trivy_scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: skyvault:latest
           format: "sarif"
@@ -139,7 +139,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF Report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
 
@@ -200,12 +200,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.bump_scan_push.outputs.COMMIT_HASH }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
         
       - name: Package Helm Chart
         run: |
@@ -214,7 +214,7 @@ jobs:
           helm package charts/skyvault --version $VERSION_NO_V --app-version $VERSION_NO_V
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.bump_scan_push.outputs.VERSION }}
           name: Release ${{ needs.bump_scan_push.outputs.VERSION }}


### PR DESCRIPTION
## Summary
- Bump workflow action versions where newer tags are available.
- Move core GitHub Actions to Node 24-capable major versions where applicable.

## Verification
- Existing GitHub Actions workflows will validate this PR.